### PR TITLE
fix package name

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,4 +1,4 @@
-package: headless
+package: graphql
 author: Kreatif GmbH
 version: '0.0.1'
 


### PR DESCRIPTION
should fix 

> AddOn "graphql" could not be installed due to the following reasons:   
         Directory name does not match the name in package.yml "headless"!     